### PR TITLE
Declare variables in first level method scope to prevent PHP warnings…

### DIFF
--- a/Classes/Xclass/InlineRecordContainerForNews.php
+++ b/Classes/Xclass/InlineRecordContainerForNews.php
@@ -51,8 +51,9 @@ class InlineRecordContainerForNews extends InlineRecordContainer
         $objectId = $domObjectId . '-' . $foreignTable . '-' . ($rec['uid'] ?? 0);
 
 
+        $renderFallback = false;
+        $recordTitle = "";
         if (is_array($raw) && !empty($raw) && $raw['CType'] !== 'gridelements_pi1') {
-            $renderFallback = false;
             $pageLayoutView = GeneralUtility::makeInstance(PageLayoutView::class);
             $pageLayoutView->doEdit = false;
             foreach ($GLOBALS['TCA']['tt_content']['columns']['CType']['config']['items'] as $val) {


### PR DESCRIPTION
… when creating a new IRRE CE

When creating a new CE inside a news record, the variables `$renderFallback` and `$recordTitle` aren't set, thus throwing a PHP warning.